### PR TITLE
Fixing wrong Browserify Name

### DIFF
--- a/data/roadmap/javascript.js
+++ b/data/roadmap/javascript.js
@@ -146,7 +146,7 @@ const javascript = [
 						name: 'parcel'
 					},
 					{ name: 'Requirejs / AMD' },
-					{ name: 'Browerify' }
+					{ name: 'Browserify' }
 				]
 			}
 		]


### PR DESCRIPTION
Change Browerify to Browserify for JavaScript Modules Bundle library.